### PR TITLE
log the exception when failing to poll

### DIFF
--- a/xkcd.py
+++ b/xkcd.py
@@ -282,8 +282,9 @@ class XKCDBot(Plugin):
         except asyncio.CancelledError:
             self.log.debug("Polling stopped")
             pass
-        except Exception:
+        except Exception as e:
             self.log.fatal("Failed to poll xkcd", exc_info=True)
+            self.log.fatal(str(e))
 
     async def _poll_xkcd(self) -> None:
         self.log.debug("Polling started")


### PR DESCRIPTION
fixes maubot/xkcd#6

After this, we need a new release. The latest release doesn't have the Python 3.10 fixes, so it breaks under latest maubot.