### PR TITLE
Retry polling if an exception is raised

### DIFF
--- a/xkcd.py
+++ b/xkcd.py
@@ -277,13 +277,15 @@ class XKCDBot(Plugin):
                     await asyncio.sleep(spam_sleep)
 
     async def poll_xkcd(self) -> None:
-        try:
-            await self._poll_xkcd()
-        except asyncio.CancelledError:
-            self.log.debug("Polling stopped")
-            pass
-        except Exception:
-            self.log.fatal("Failed to poll xkcd", exc_info=True)
+        while True:
+            try:
+                await self._poll_xkcd()
+            except asyncio.CancelledError:
+                self.log.debug("Polling stopped")
+                return
+            except Exception:
+                self.log.exception("Failed to poll xkcd")
+                await asyncio.sleep(self.config["poll_interval"])
 
     async def _poll_xkcd(self) -> None:
         self.log.debug("Polling started")


### PR DESCRIPTION
If the polling loop bails then until the xkcd plugin instance is restarted, no more XKCDs will be posted into subscribed rooms.

It took us about 4 weeks to realise we'd not seen an XKCD be posted.. shame
The final blow was
```python
[2024-08-28 20:25:05,570] [CRITICAL@maubot.instance.xkcd] Failed to poll xkcd
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/aiohttp/connector.py", line 1173, in _create_direct_connection
    hosts = await asyncio.shield(host_resolved)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/aiohttp/connector.py", line 884, in _resolve_host
    addrs = await self._resolver.resolve(host, port, family=self._family)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/aiohttp/resolver.py", line 33, in resolve
    infos = await self._loop.getaddrinfo(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 901, in getaddrinfo
    return await self.run_in_executor(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/socket.py", line 963, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
socket.gaierror: [Errno -3] Try again

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/plugins/xyz.maubot.xkcd-v1.2.0-ts1711321017734.mbp/xkcd.py", line 293, in poll_xkcd
    await self._poll_xkcd()
  File "/data/plugins/xyz.maubot.xkcd-v1.2.0-ts1711321017734.mbp/xkcd.py", line 310, in _poll_xkcd
    info = await self._get_media_info(latest.img)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/plugins/xyz.maubot.xkcd-v1.2.0-ts1711321017734.mbp/xkcd.py", line 212, in _get_media_info
    resp = await self.http.get(image_url)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/aiohttp/client.py", line 578, in _request
    conn = await self._connector.connect(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/aiohttp/connector.py", line 544, in connect
    proto = await self._create_connection(req, traces, timeout)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/aiohttp/connector.py", line 911, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/aiohttp/connector.py", line 1187, in _create_direct_connection
    raise ClientConnectorError(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host imgs.xkcd.com:443 ssl:default [Try again]
```